### PR TITLE
Add language (name + multiverse id) scrapping.

### DIFF
--- a/src/com/gelakinetic/GathererScraper/GathererScraper.java
+++ b/src/com/gelakinetic/GathererScraper/GathererScraper.java
@@ -681,6 +681,13 @@ public class GathererScraper {
 						card.mColor = "W";
 					}
 				}
+				
+				//Scrape foreign language page, scrapping the name and the multiverse id of the card in foreign languages.
+				HashMap<String, String> foreignNames = new HashMap<>();
+				HashMap<String, Integer> foreignMultiverseIds = new HashMap<>();
+				scrapeLanguage(card.mMultiverseId, foreignNames, foreignMultiverseIds);
+				card.mForeignMultiverseIds.putAll(foreignMultiverseIds);
+				card.mForeignNames.putAll(foreignNames);
 	
 				card.clearNulls();
 				scrapedCards.add(card);
@@ -703,6 +710,46 @@ public class GathererScraper {
 		}
 		return scrapedCardsAllPages;
 	}
+	
+	/**
+	 * Scrape the Language Gatherer page of the card with the english multiverse id given in the params. 
+	 * @param englishMultiverseId The english multiverse ID of the card for which we will scrape the foreign language infos. 
+	 * @param foreignNames A HashMap where will be added the foreign names of the card, indexed by their language code.
+	 * @param foreignMultiverseIds A HashMap where will be added the foreign multiverse ID of the card, indexed by their language code.
+	 */
+	private static void scrapeLanguage(
+			int englishMultiverseId,
+			HashMap<String, String> foreignNames,
+			HashMap<String, Integer> foreignMultiverseIds) {	
+		if(englishMultiverseId == 0 || foreignNames == null || foreignMultiverseIds == null)
+			return;
+
+		Document page = ConnectWithRetries(CardGS.getLanguageUrl(englishMultiverseId));
+		Elements elts = page.getElementsByAttributeValueContaining("class", "cardItem");
+		
+		for(Element elt : elts) {
+			String language = elt.child(1).html();
+			if(language.equals("English")) language = Language.English;
+			else if(language.equals("German")) language = Language.German;
+			else if(language.equals("French")) language = Language.French;
+			else if(language.equals("Japanese")) language = Language.Japanese;
+			else if(language.equals("Portuguese (Brazil)")) language = Language.Portuguese_Brazil;
+			else if(language.equals("Russian")) language = Language.Russian;
+			else if(language.equals("Chinese Traditional")) language = Language.Chinese_Traditional;
+			else if(language.equals("Chinese Simplified")) language = Language.Chinese_Simplified;
+			else if(language.equals("Korean")) language = Language.Korean;
+			else if(language.equals("Italian")) language = Language.Italian;
+			else if(language.equals("Spanish")) language = Language.Spanish;
+			else continue;
+			
+			String name = elt.child(0).text();
+			String multiverseId = elt.child(0).child(0).attr("href").split("=")[1];
+			
+			foreignMultiverseIds.put(language, Integer.parseInt(multiverseId));
+			foreignNames.put(language, name);
+		}
+	}
+
 
 	/**
 	 * Add links to the text to handle meld cards

--- a/src/com/gelakinetic/GathererScraper/JsonTypes/Card.java
+++ b/src/com/gelakinetic/GathererScraper/JsonTypes/Card.java
@@ -1,5 +1,6 @@
 package com.gelakinetic.GathererScraper.JsonTypes;
 
+import java.util.HashMap;
 import com.gelakinetic.mtgfam.helpers.database.CardDbAdapter;
 
 /*
@@ -12,6 +13,9 @@ public class Card {
 
     // The card's name
     public String mName = "";
+	
+    // The card's name in foreign (non english) language
+    public HashMap<String,String> mForeignNames	= new HashMap<String,String>();
 
     // The card's mana cost
     public String mManaCost = "";
@@ -45,6 +49,9 @@ public class Card {
 
     // The card's multiverse id
     public int mMultiverseId = 0;
+
+    // The card's multiverse id for foreign (non english) language
+    public HashMap<String,Integer> mForeignMultiverseIds = new HashMap<String,Integer>();
 
     // The card's power. Not an integer (i.e. *+1, X)
     public float mPower = CardDbAdapter.NO_ONE_CARES;

--- a/src/com/gelakinetic/GathererScraper/JsonTypesGS/CardGS.java
+++ b/src/com/gelakinetic/GathererScraper/JsonTypesGS/CardGS.java
@@ -2,6 +2,7 @@ package com.gelakinetic.GathererScraper.JsonTypesGS;
 
 import java.io.Serializable;
 import java.util.Comparator;
+import java.util.HashMap;
 
 import org.apache.commons.lang3.SerializationUtils;
 import com.gelakinetic.GathererScraper.JsonTypes.Card;
@@ -39,6 +40,15 @@ public class CardGS extends Card implements Serializable, Comparable<CardGS> {
 	public static String getUrl(int multiverseId) {
 		return "http://gatherer.wizards.com/Pages/Card/Details.aspx?multiverseid=" + multiverseId;
 	}
+	
+	/**
+	 * Returns a string URL for this card's gatherer language page
+	 *
+	 * @return A string of the URL for this card's gatherer language page
+	 */
+	public static String getLanguageUrl(int multiverseId) {
+		return "http://gatherer.wizards.com/Pages/Card/Languages.aspx?multiverseid=" + multiverseId;
+	}
 
 	/**
 	 * Turns any null fields into empty strings
@@ -46,6 +56,9 @@ public class CardGS extends Card implements Serializable, Comparable<CardGS> {
 	public void clearNulls() {
 		if (null == mName) {
 			mName = "";
+		}
+		if (null == mForeignNames) {
+			mForeignNames = new HashMap<String, String>();
 		}
 		if (null == mManaCost) {
 			mManaCost = "";
@@ -70,6 +83,9 @@ public class CardGS extends Card implements Serializable, Comparable<CardGS> {
 		}
 		if (null == mColor) {
 			mColor = "";
+		}
+		if (null == mForeignMultiverseIds) {
+			mForeignMultiverseIds = new HashMap<String, Integer>();
 		}
 		/* Don't worry about mRarity, mPower, mToughness, or mLoyalty */
 	}

--- a/src/com/gelakinetic/GathererScraper/Language.java
+++ b/src/com/gelakinetic/GathererScraper/Language.java
@@ -1,0 +1,19 @@
+package com.gelakinetic.GathererScraper;
+
+/**
+ * Class containing String constants for languages' code.
+ *
+ */
+public class Language {
+	public static final String Chinese_Traditional = "zh_HANT";
+	public static final String Chinese_Simplified = "zh_HANS";
+	public static final String French = "fr";
+	public static final String German = "de";
+	public static final String Italian = "it";
+	public static final String Japanese = "ja";
+	public static final String Portuguese_Brazil = "pt_BR";
+	public static final String Russian = "ru";
+	public static final String Spanish = "es";
+	public static final String Korean = "ko";
+	public static final String English = "en";
+}


### PR DESCRIPTION
When scrapping a card, GathererScraper will now also scrap the foreign names of the card, and their related multiverse ID.

Issue : https://github.com/AEFeinstein/GathererScraper/issues/10